### PR TITLE
Add model callback to be base of resource.

### DIFF
--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -8,6 +8,7 @@ defmodule JaResource do
 
   defmacro __using__(opts) do
     quote do
+      use JaResource.Model
       unquote(JaResource.use_action_behaviours(opts))
     end
   end
@@ -44,6 +45,7 @@ defmodule JaResource do
   end
 end
 
+
 defmodule JaResource.Records do
   use Behaviour
 
@@ -52,6 +54,10 @@ defmodule JaResource.Records do
   defmacro __using__(_) do
     quote do
       @behaviour JaResource.Records
+      
+      def records(_conn), do: model()
+
+      defoverridable [records: 1]
     end
   end
 end

--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -18,7 +18,9 @@ defmodule JaResource.Create do
         |> JaResource.Create.respond(conn)
       end
 
-      def handle_create(conn, params), do: records(conn)
+      def handle_create(_conn, attributes) do 
+        __MODULE__.model.changeset(__MODULE__.model.__struct__, attributes)
+      end
 
       defoverridable [create: 2, handle_create: 2]
     end

--- a/lib/ja_resource/model.ex
+++ b/lib/ja_resource/model.ex
@@ -1,0 +1,41 @@
+defmodule JaResource.Model do
+  use Behaviour
+
+  @doc """
+  Must return the module implementing `Ecto.Schema` to be represented.
+
+  Example:
+
+      def model, do: MyApp.Models.Post
+
+  Defaults to the name of the controller, for example the controller
+  `MyApp.V1.PostController` would serve the `MyApp.Post` model.
+
+
+  Used by the default implementations for `handle_create/2`, `handle_update/3`,
+  and `records/1`.
+  """
+  @callback model() :: module
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour JaResource.Records
+      
+      @inferred_model JaResource.Model.model_from_controller(__MODULE__)
+      def model(), do: @inferred_model 
+
+      defoverridable [model: 0]
+    end
+  end
+
+  def model_from_controller(module) do
+    [_elixir, app | rest] = module
+                            |> Atom.to_string
+                            |> String.split(".")
+
+    [controller | _ ] = Enum.reverse(rest)
+    inferred = String.replace(controller, "Controller", "")
+    
+    String.to_atom("Elixir.#{app}.#{inferred}")
+  end
+end

--- a/lib/ja_resource/update.ex
+++ b/lib/ja_resource/update.ex
@@ -22,6 +22,9 @@ defmodule JaResource.Update do
       end
 
       def handle_update(conn, nil, _params), do: nil
+      def handle_update(_conn, model, attributes) do
+        __MODULE__.model.changeset(model, attributes)
+      end
 
       defoverridable [update: 2, handle_update: 3]
     end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,10 @@ defmodule JaResource.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:ecto, ">= 1.0.0"},
+      {:plug, ">= 1.0.0"}
+    ]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{"decimal": {:hex, :decimal, "1.1.1"},
+  "ecto": {:hex, :ecto, "1.1.1"},
+  "plug": {:hex, :plug, "1.0.3"},
+  "poolboy": {:hex, :poolboy, "1.5.1"}}

--- a/test/ja_resource/model_test.exs
+++ b/test/ja_resource/model_test.exs
@@ -1,0 +1,11 @@
+defmodule JaResource.ModelTest do
+  use ExUnit.Case
+
+  import JaResource.Model
+
+  test "model can be determined by the controller name" do
+    assert model_from_controller(MyApp.SandwichController) == MyApp.Sandwich
+    assert model_from_controller(MyApp.V1.SaladController) == MyApp.Salad
+    assert model_from_controller(MyApp.API.V1.CookieController) == MyApp.Cookie
+  end
+end


### PR DESCRIPTION
Allows handle_update and handle_create to be dynamically defined but
optionally overridden.

//cc @beerlington @totallymike 

Makes the handle_update/create callbacks optional.