### PR TITLE
Adds serialization behaviour for setting opts.

### DIFF
--- a/lib/ja_resource/serializable.ex
+++ b/lib/ja_resource/serializable.ex
@@ -1,0 +1,48 @@
+defmodule JaResource.Serializable do
+  @moduledoc """
+  The `JaResource.Serializable` behavior is used to send serialization options
+  such as `fields` and `include` to the serializer.
+
+  It is `use`d by the `JaResource.Index` and `JaResource.Show` actions.
+
+  `use` of this module defines a default implementation that passes `fields`
+  and `include` params through un-touched. This may be overridden in your
+  controller. For example:
+
+      def serialization_opts(_conn, params) do
+        %{
+          fields: params["fields"] || %{"post" => "title,body"}
+        }
+      end
+
+  """
+
+  use Behaviour
+
+  @doc """
+  Converts full list of params into serialization opts.
+
+  Typically this callback returns the list of fields and includes that were
+  optionally requested by the stack.
+
+  See http://github.com/AgilionApps/ja_serializer for option format.
+  """
+  @callback serialization_opts(Plug.Conn.t, map) :: map
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour JaResource.Serializable
+
+      def serialization_opts(_conn, %{"fields" => f, "include" => i}),
+        do: %{include: i, fields: f}
+      def serialization_opts(_conn, %{"include" => i}),
+        do: %{include: i}
+      def serialization_opts(_conn, %{"fields" => f}),
+        do: %{fields: f}
+      def serialization_opts(_conn, _params),
+        do: %{}
+
+      defoverridable [serialization_opts: 2]
+    end
+  end
+end

--- a/test/ja_resource/serializable_test.exs
+++ b/test/ja_resource/serializable_test.exs
@@ -1,0 +1,51 @@
+defmodule JaResource.SerializableTest do
+  use ExUnit.Case
+
+  defmodule Default do
+    use JaResource.Serializable
+  end
+
+  defmodule Override do
+    use JaResource.Serializable
+
+    def serialization_opts(_conn, params) do
+      %{fields: %{"article" => params["fields"]["post"]}}
+    end
+  end
+
+  test "default behaviour - no opts" do
+    conn = %Plug.Conn{}
+    given = %{}
+    expected = %{}
+    assert Default.serialization_opts(conn, given) == expected
+  end
+
+  test "default behaviour - both opts" do
+    conn = %Plug.Conn{}
+    given = %{"fields" => %{"post" => "title,body"}, "include" => "author"}
+    expected = %{fields: %{"post" => "title,body"}, include: "author"}
+    assert Default.serialization_opts(conn, given) == expected
+  end
+
+  test "default behaviour - field only" do
+    conn = %Plug.Conn{}
+    given = %{"fields" => %{"post" => "title,body"}}
+    expected = %{fields: %{"post" => "title,body"}}
+    assert Default.serialization_opts(conn, given) == expected
+  end
+
+  test "default behaviour - include only" do
+    conn = %Plug.Conn{}
+    given = %{"include" => "author"}
+    expected = %{include: "author"}
+    assert Default.serialization_opts(conn, given) == expected
+  end
+
+  test "overridden behaviour" do
+    conn = %Plug.Conn{}
+    given = %{"fields" => %{"post" => "title,body"}}
+    expected = %{fields: %{"article" => "title,body"}}
+    assert Override.serialization_opts(conn, given) == expected
+  end
+
+end


### PR DESCRIPTION
Allows control of JSON-API `fields` and `include` params.

Basically just passes them through to the serializer, but you can optionally override and tweak as you need.

//cc @beerlington @totallymike 