### PR TITLE
render an errors object on 404

### DIFF
--- a/lib/ja_resource/show.ex
+++ b/lib/ja_resource/show.ex
@@ -63,7 +63,14 @@ defmodule JaResource.Show do
 
   @doc false
   def respond(%Plug.Conn{} = conn, _old_conn, _controller), do: conn
-  def respond(nil, conn, _controller), do: send_resp(conn, :not_found, "")
+  def respond(nil, conn, _controller) do
+    conn
+    |> put_status(:not_found)
+    |> Phoenix.Controller.render(:errors, data: %{
+        status: 404,
+        title: "Not Found",
+        detail: "The resource was not found"})
+  end
   def respond(model, conn, controller) do
     opts = controller.serialization_opts(conn, conn.query_params)
     Phoenix.Controller.render(conn, :show, data: model, opts: opts)

--- a/test/ja_resource/show_test.exs
+++ b/test/ja_resource/show_test.exs
@@ -20,6 +20,10 @@ defmodule JaResource.ShowTest do
     conn = prep_conn(:get, "/posts/404")
     response = DefaultController.show(conn, %{"id" => 404})
     assert response.status == 404
+    {:ok, body} = Poison.decode(response.resp_body)
+    assert body == %{"action" => "errors.json",
+                     "errors" => %{"detail" => "The resource was not found",
+                     "status" => 404, "title" => "Not Found"}}
   end
 
   test "default implementation return 200 if found" do


### PR DESCRIPTION
renders an errors object on 404 when fetching a non-existent resource in "show".