### PR TITLE
Parse params without attributes

### DIFF
--- a/lib/ja_resource/attributes.ex
+++ b/lib/ja_resource/attributes.ex
@@ -50,11 +50,13 @@ defmodule JaResource.Attributes do
   end
 
   @doc false
-  def from_params(%{"data" => %{"attributes" => attrs}} = params) do
-    params["data"]
+  def from_params(%{"data" => data}) do
+    attrs = data["attributes"] || %{}
+
+    data
     |> parse_relationships
     |> Map.merge(attrs)
-    |> Map.put_new("type", params["data"]["type"])
+    |> Map.put_new("type", data["type"])
   end
 
   defp parse_relationships(%{"relationships" => nil}) do

--- a/lib/ja_resource/attributes.ex
+++ b/lib/ja_resource/attributes.ex
@@ -13,7 +13,7 @@ defmodule JaResource.Attributes do
   @doc """
   Used to determine which attributes are permitted during create and update.
 
-  The attributes map (the sencond argument) is a "flattened" version including
+  The attributes map (the second argument) is a "flattened" version including
   the values at `data/attributes`, `data/type` and any relationship values in
   `data/relationships/[name]/data/id` as `name_id`.
 
@@ -37,7 +37,7 @@ defmodule JaResource.Attributes do
       end
 
   """
-  @callback permitted_attributes(Plug.Conn.t, JaResource.attributes, :update | :create) :: JaResourse.attributes
+  @callback permitted_attributes(Plug.Conn.t, JaResource.attributes, :update | :create) :: JaResource.attributes
 
   defmacro __using__(_) do
     quote do

--- a/test/ja_resource/attributes_test.exs
+++ b/test/ja_resource/attributes_test.exs
@@ -80,4 +80,23 @@ defmodule JaResource.AttributesTest do
     actual = JaResource.Attributes.from_params(params)
     assert actual == merged
   end
+
+  test "formatting only relationships from json-api params" do
+    params = %{
+      "data" => %{
+        "type" => "post",
+        "relationships" => %{
+          "category" => %{
+            "data" => %{"type" => "category", "id" => "1"}
+          }
+        }
+      }
+    }
+    merged = %{
+      "type" => "post",
+      "category_id" => "1"
+    }
+    actual = JaResource.Attributes.from_params(params)
+    assert actual == merged
+  end
 end


### PR DESCRIPTION
Since [attributes are not strictly required][0] in e.g. relationship-only updates, this PR changes the parameter parsing to default to an empty map when there are no attributes.

Please let me know what you think!

[0]: http://jsonapi.org/format/#document-resource-objects