### PR TITLE
Spike out an alternate approach.

### DIFF
--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -1,51 +1,18 @@
 defmodule JaResource do
-  use Behaviour
-
   @type record :: map() | Ecto.Schema.t
   @type records :: module | Ecto.Query.t | list(record)
   @type params :: map()
   @type attributes :: map()
   @type id :: String.t
 
-  @doc """
-  Defines the module `use`-ing `Ecto.Repo` to be used by the controller.
-
-  Defaults to the value set in config if present:
-
-      config :ja_resource,
-         repo: MyApp.Repo
-
-  Default can be overridden per controller:
-
-      def repo, do: MyApp.SecondaryRepo
-
-  """
-  @callback repo() :: module
-
   defmacro __using__(_opts) do
     quote do
-      @behaviour JaResource
-      unquote(JaResource.default_repo)
-
-      # TODO: Extract JaResource.Repo to own module
-      #use JaResourse.Repo
+      use JaResource.Repo
       use JaResource.Index
       use JaResource.Show
       use JaResource.Create
       use JaResource.Update
       use JaResource.Delete
-
-      plug JaResource.Plug
-    end
-  end
-
-  @doc false
-  def default_repo do
-    quote do
-      if Application.get_env(:ja_resource, :repo) do
-        def repo, do: Application.get_env(:ja_resource, :repo)
-        defoverridable [repo: 0]
-      end
     end
   end
 end

--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -7,7 +7,6 @@ defmodule JaResource do
 
   defmacro __using__(_opts) do
     quote do
-      use JaResource.Repo
       use JaResource.Index
       use JaResource.Show
       use JaResource.Create
@@ -15,4 +14,8 @@ defmodule JaResource do
       use JaResource.Delete
     end
   end
+
+  @behavour Plug
+  defdelegate init(opts),       to: JaResource.Plug
+  defdelegate call(conn, opts), to: JaResource.Plug
 end

--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -22,25 +22,20 @@ defmodule JaResource do
   """
   @callback repo() :: module
 
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       @behaviour JaResource
-      unquote(JaResource.use_action_behaviours(opts))
       unquote(JaResource.default_repo)
-    end
-  end
 
-  @doc false
-  def use_action_behaviours(opts) do
-    available = [:index, :show, :create, :update, :delete]
-    allowed = (opts[:only] || available -- (opts[:except] || []))
+      # TODO: Extract JaResource.Repo to own module
+      #use JaResourse.Repo
+      use JaResource.Index
+      use JaResource.Show
+      use JaResource.Create
+      use JaResource.Update
+      use JaResource.Delete
 
-    quote bind_quoted: [allowed: allowed] do
-      if :index  in allowed, do: use JaResource.Index
-      if :show   in allowed, do: use JaResource.Show
-      if :create in allowed, do: use JaResource.Create
-      if :update in allowed, do: use JaResource.Update
-      if :delete in allowed, do: use JaResource.Delete
+      plug JaResource.Plug
     end
   end
 

--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -3,23 +3,19 @@ defmodule JaResource.Create do
   import Plug.Conn
 
   @moduledoc """
-  Provides default `create/2` action implementation, `handle_create/2` callback.
-
-  This behaviour is used by JaResource unless excluded by via only/except option.
+  Defines a behaviour for creating a resource and the function to execute it.
 
   It relies on (and uses):
 
+    * JaResource.Repo
     * JaResource.Model
     * JaResource.Attributes
 
-  When used JaResource.Create defines the `create/2` action suitable for
-  handling json-api requests.
-
-  To customize the behaviour of the create action the following callbacks can
-  be implemented:
+  When used JaResource.Create defines the following overrideable callbacks:
 
     * handle_create/2
     * JaResource.Attributes.permitted_attributes/3
+    * JaResource.Repo.repo/1
 
   """
 
@@ -36,7 +32,6 @@ defmodule JaResource.Create do
   a list of errors (`{:error, [email: "is not valid"]}` or a conn with
   any response/body.
 
-
   Example custom implementation:
 
       def handle_create(_conn, attributes) do
@@ -49,6 +44,7 @@ defmodule JaResource.Create do
   defmacro __using__(_) do
     quote do
       @behaviour JaResource.Create
+      use JaResource.Repo
       use JaResource.Attributes
 
       def handle_create(_conn, attributes) do
@@ -59,6 +55,13 @@ defmodule JaResource.Create do
     end
   end
 
+  @doc """
+  Creates a resource given a module using Create and a connection.
+
+      Create.call(ArticleController, conn)
+
+  Dispatched by JaResource.Plug when phoenix action is create.
+  """
   def call(controller, conn) do
     merged = JaResource.Attributes.from_params(conn.params)
     attributes = controller.permitted_attributes(conn, merged, :create)

--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -1,6 +1,7 @@
 defmodule JaResource.Create do
   use Behaviour
   import Plug.Conn
+  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `create/2` action implementation, `handle_create/2` callback.
@@ -51,21 +52,22 @@ defmodule JaResource.Create do
       @behaviour JaResource.Create
       use JaResource.Attributes
 
-      def create(conn, params) do
-        merged = JaResource.Attributes.from_params(params)
-        attributes = permitted_attributes(conn, merged, :create)
-        conn
-        |> handle_create(attributes)
-        |> JaResource.Create.insert(__MODULE__)
-        |> JaResource.Create.respond(conn)
-      end
-
       def handle_create(_conn, attributes) do
         __MODULE__.model.changeset(__MODULE__.model.__struct__, attributes)
       end
 
       defoverridable [handle_create: 2]
     end
+  end
+
+  def call(conn) do
+    controller = controller_module(conn)
+    merged = JaResource.Attributes.from_params(conn.params)
+    attributes = controller.permitted_attributes(conn, merged, :create)
+    conn
+    |> controller.handle_create(attributes)
+    |> JaResource.Create.insert(controller)
+    |> JaResource.Create.respond(conn)
   end
 
   @doc false

--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -1,7 +1,6 @@
 defmodule JaResource.Create do
   use Behaviour
   import Plug.Conn
-  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `create/2` action implementation, `handle_create/2` callback.
@@ -60,8 +59,7 @@ defmodule JaResource.Create do
     end
   end
 
-  def call(conn) do
-    controller = controller_module(conn)
+  def call(controller, conn) do
     merged = JaResource.Attributes.from_params(conn.params)
     attributes = controller.permitted_attributes(conn, merged, :create)
     conn

--- a/lib/ja_resource/delete.ex
+++ b/lib/ja_resource/delete.ex
@@ -1,6 +1,7 @@
 defmodule JaResource.Delete do
   use Behaviour
   import Plug.Conn
+  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `delete/2` action implementation, `handle_delete/3` callback.
@@ -45,20 +46,20 @@ defmodule JaResource.Delete do
     quote do
       use JaResource.Record
       @behaviour JaResource.Delete
-
-      def delete(conn, %{"id" => id}) do
-        model = record(conn, id)
-
-        conn
-        |> handle_delete(model)
-        |> JaResource.Delete.respond(conn)
-      end
-
       def handle_delete(conn, nil), do: nil
       def handle_delete(conn, model), do: __MODULE__.repo.delete(model)
 
       defoverridable [handle_delete: 2]
     end
+  end
+
+  def call(conn) do
+    controller = controller_module(conn)
+    model = controller.record(conn, conn.params["id"])
+
+    conn
+    |> controller.handle_delete(model)
+    |> JaResource.Delete.respond(conn)
   end
 
   @doc false

--- a/lib/ja_resource/delete.ex
+++ b/lib/ja_resource/delete.ex
@@ -1,7 +1,6 @@
 defmodule JaResource.Delete do
   use Behaviour
   import Plug.Conn
-  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `delete/2` action implementation, `handle_delete/3` callback.
@@ -53,8 +52,7 @@ defmodule JaResource.Delete do
     end
   end
 
-  def call(conn) do
-    controller = controller_module(conn)
+  def call(controller, conn) do
     model = controller.record(conn, conn.params["id"])
 
     conn

--- a/lib/ja_resource/delete.ex
+++ b/lib/ja_resource/delete.ex
@@ -3,12 +3,11 @@ defmodule JaResource.Delete do
   import Plug.Conn
 
   @moduledoc """
-  Provides default `delete/2` action implementation, `handle_delete/3` callback.
-
-  This behaviour is used by JaResource unless excluded by via only/except option.
+  Defines a behaviour for deleting a resource and the function to execute it.
 
   It relies on (and uses):
 
+    * JaResource.Repo
     * JaResource.Record
 
   When used JaResource.Delete defines the `delete/2` action suitable for
@@ -17,8 +16,9 @@ defmodule JaResource.Delete do
   To customize the behaviour of the update action the following callbacks can
   be implemented:
 
-    * record/2
     * handle_delete/2
+    * JaResource.Record.record/2
+    * JaResource.Repo.repo/0
 
   """
 
@@ -43,6 +43,7 @@ defmodule JaResource.Delete do
 
   defmacro __using__(_) do
     quote do
+      use JaResource.Repo
       use JaResource.Record
       @behaviour JaResource.Delete
       def handle_delete(conn, nil), do: nil
@@ -52,6 +53,9 @@ defmodule JaResource.Delete do
     end
   end
 
+  @doc """
+  Execute the delete action on a given module implementing Delete behaviour and conn.
+  """
   def call(controller, conn) do
     model = controller.record(conn, conn.params["id"])
 

--- a/lib/ja_resource/index.ex
+++ b/lib/ja_resource/index.ex
@@ -2,12 +2,11 @@ defmodule JaResource.Index do
   use Behaviour
 
   @moduledoc """
-  Provides `index/2` action, and `filter/3`, `sort/3` and `handle_show/2` callbacks.
-
-  This behaviour is used by JaResource unless excluded by via only/except option.
+  Provides `handle_index/2`, `filter/3` and `sort/3` callbacks.
 
   It relies on (and uses):
 
+    * JaResource.Repo
     * JaResource.Records
     * JaResource.Serializable
 
@@ -20,6 +19,8 @@ defmodule JaResource.Index do
     * filter/3
     * sort/3
     * JaResource.Records.records/1
+    * JaResource.Repo.repo/0
+    * JaResource.Serializable.serialization_opts/2
 
   """
 
@@ -42,7 +43,8 @@ defmodule JaResource.Index do
         end
       end
 
-  In most cases JaResource.Records.records/1 is the better customization hook.
+  In most cases JaResource.Records.records/1, filter/3, and sort/3 are the 
+  better customization hooks.
   """
   @callback handle_index(Plug.Conn.t, map) :: Plug.Conn.t | JaResource.records
 
@@ -50,6 +52,9 @@ defmodule JaResource.Index do
   @callback sort(String.t, JaResource.records, String.t) :: JaResource.records
 
 
+  @doc """
+  Execute the index action on a given module implementing Index behaviour and conn.
+  """
   def call(controller, conn) do
     conn
     |> controller.handle_index(conn.params)

--- a/lib/ja_resource/index.ex
+++ b/lib/ja_resource/index.ex
@@ -61,6 +61,7 @@ defmodule JaResource.Index do
 
   defmacro __using__(_) do
     quote do
+      use JaResource.Repo
       use JaResource.Records
       use JaResource.Serializable
       @behaviour JaResource.Index

--- a/lib/ja_resource/index.ex
+++ b/lib/ja_resource/index.ex
@@ -1,6 +1,5 @@
 defmodule JaResource.Index do
   use Behaviour
-  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides `index/2` action, and `filter/3`, `sort/3` and `handle_show/2` callbacks.
@@ -51,8 +50,7 @@ defmodule JaResource.Index do
   @callback sort(String.t, JaResource.records, String.t) :: JaResource.records
 
 
-  def call(conn) do
-    controller = controller_module(conn)
+  def call(controller, conn) do
     conn
     |> controller.handle_index(conn.params)
     |> JaResource.Index.filter(conn, controller)

--- a/lib/ja_resource/plug.ex
+++ b/lib/ja_resource/plug.ex
@@ -1,0 +1,28 @@
+defmodule JaResource.Plug do
+  import Plug.Conn
+  alias Phoenix.Controller
+  @behaviour Plug
+
+  @available [:index, :show, :create, :update, :delete]
+
+  def init(opts) do
+    Keyword.put(opts, :allowed, (opts[:only] || @available -- (opts[:except] || [])))
+  end
+
+  def call(conn, opts) do
+    action = Controller.action_name(conn)
+    if action in opts[:allowed] do
+      conn
+      |> dispatch_resource(action)
+      |> halt
+    else
+      conn
+    end
+  end
+
+  defp dispatch_resource(conn, :index),  do: JaResource.Index.call(conn)
+  defp dispatch_resource(conn, :show),   do: JaResource.Show.call(conn)
+  defp dispatch_resource(conn, :create), do: JaResource.Create.call(conn)
+  defp dispatch_resource(conn, :update), do: JaResource.Update.call(conn)
+  defp dispatch_resource(conn, :delete), do: JaResource.Delete.call(conn)
+end

--- a/lib/ja_resource/plug.ex
+++ b/lib/ja_resource/plug.ex
@@ -1,6 +1,7 @@
 defmodule JaResource.Plug do
   import Plug.Conn
   alias Phoenix.Controller
+  alias JaResource.{Index,Show,Create,Update,Delete}
   @behaviour Plug
 
   @available [:index, :show, :create, :update, :delete]
@@ -10,19 +11,20 @@ defmodule JaResource.Plug do
   end
 
   def call(conn, opts) do
-    action = Controller.action_name(conn)
+    action     = Controller.action_name(conn)
+    controller = Controller.controller_module(conn)
     if action in opts[:allowed] do
       conn
-      |> dispatch_resource(action)
+      |> dispatch(controller, action)
       |> halt
     else
       conn
     end
   end
 
-  defp dispatch_resource(conn, :index),  do: JaResource.Index.call(conn)
-  defp dispatch_resource(conn, :show),   do: JaResource.Show.call(conn)
-  defp dispatch_resource(conn, :create), do: JaResource.Create.call(conn)
-  defp dispatch_resource(conn, :update), do: JaResource.Update.call(conn)
-  defp dispatch_resource(conn, :delete), do: JaResource.Delete.call(conn)
+  defp dispatch(conn, controller, :index),  do: Index.call(controller, conn)
+  defp dispatch(conn, controller, :show),   do: Show.call(controller, conn)
+  defp dispatch(conn, controller, :create), do: Create.call(controller, conn)
+  defp dispatch(conn, controller, :update), do: Update.call(controller, conn)
+  defp dispatch(conn, controller, :delete), do: Delete.call(controller, conn)
 end

--- a/lib/ja_resource/plug.ex
+++ b/lib/ja_resource/plug.ex
@@ -7,7 +7,13 @@ defmodule JaResource.Plug do
   @available [:index, :show, :create, :update, :delete]
 
   def init(opts) do
-    Keyword.put(opts, :allowed, (opts[:only] || @available -- (opts[:except] || [])))
+    allowed = cond do
+      opts[:only]   -> opts[:only] -- (opts[:only] -- @available)
+      opts[:except] -> @available -- opts[:except]
+      true          -> @available
+    end
+
+    [allowed: allowed]
   end
 
   def call(conn, opts) do

--- a/lib/ja_resource/records.ex
+++ b/lib/ja_resource/records.ex
@@ -2,7 +2,7 @@ defmodule JaResource.Records do
   use Behaviour
 
   @moduledoc """
-  Provides the `records/1` callback used for filtering records to be served.
+  Provides the `records/1` callback used for querying records to be served.
 
   This behaviour is used by the following JaResource actions:
 

--- a/lib/ja_resource/repo.ex
+++ b/lib/ja_resource/repo.ex
@@ -1,0 +1,34 @@
+defmodule JaResource.Repo do
+  use Behaviour
+
+  @doc """
+  Defines the module `use`-ing `Ecto.Repo` to be used by the controller.
+
+  Defaults to the value set in config if present:
+
+      config :ja_resource,
+         repo: MyApp.Repo
+
+  Default can be overridden per controller:
+
+      def repo, do: MyApp.SecondaryRepo
+
+  """
+  @callback repo() :: module
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour JaResource.Repo
+      unquote(default_repo)
+    end
+  end
+
+  @doc false
+  def default_repo do
+    quote do
+      if Application.get_env(:ja_resource, :repo) do
+        def repo, do: Application.get_env(:ja_resource, :repo)
+        defoverridable [repo: 0]
+      end
+    end
+  end
+end

--- a/lib/ja_resource/show.ex
+++ b/lib/ja_resource/show.ex
@@ -3,9 +3,7 @@ defmodule JaResource.Show do
   import Plug.Conn
 
   @moduledoc """
-  Provides default `show/2` action implementation, `handle_show/2` callback.
-
-  This behaviour is used by JaResource unless excluded by via only/except option.
+  Defines a behaviour for displaying a resource and the function to execute it.
 
   It relies on (and uses):
 
@@ -55,6 +53,9 @@ defmodule JaResource.Show do
     end
   end
 
+  @doc """
+  Execute the show action on a given module implementing Show behaviour and conn.
+  """
   def call(controller, conn) do
     conn
     |> controller.handle_show(conn.params["id"])

--- a/lib/ja_resource/show.ex
+++ b/lib/ja_resource/show.ex
@@ -1,7 +1,6 @@
 defmodule JaResource.Show do
   use Behaviour
   import Plug.Conn
-  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `show/2` action implementation, `handle_show/2` callback.
@@ -56,8 +55,7 @@ defmodule JaResource.Show do
     end
   end
 
-  def call(conn) do
-    controller = controller_module(conn)
+  def call(controller, conn) do
     conn
     |> controller.handle_show(conn.params["id"])
     |> JaResource.Show.respond(conn, controller)

--- a/lib/ja_resource/show.ex
+++ b/lib/ja_resource/show.ex
@@ -1,6 +1,7 @@
 defmodule JaResource.Show do
   use Behaviour
   import Plug.Conn
+  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `show/2` action implementation, `handle_show/2` callback.
@@ -49,16 +50,17 @@ defmodule JaResource.Show do
       use JaResource.Serializable
       @behaviour JaResource.Show
 
-      def show(conn, %{"id" => id}) do
-        conn
-        |> handle_show(id)
-        |> JaResource.Show.respond(conn, __MODULE__)
-      end
-
       def handle_show(conn, id), do: record(conn, id)
 
       defoverridable [handle_show: 2]
     end
+  end
+
+  def call(conn) do
+    controller = controller_module(conn)
+    conn
+    |> controller.handle_show(conn.params["id"])
+    |> JaResource.Show.respond(conn, controller)
   end
 
   @doc false

--- a/lib/ja_resource/update.ex
+++ b/lib/ja_resource/update.ex
@@ -3,9 +3,7 @@ defmodule JaResource.Update do
   import Plug.Conn
 
   @moduledoc """
-  Provides default `update/2` action implementation, `handle_update/3` callback.
-
-  This behaviour is used by JaResource unless excluded by via only/except option.
+  Defines a behaviour for updating a resource and the function to execute it.
 
   It relies on (and uses):
 
@@ -18,7 +16,8 @@ defmodule JaResource.Update do
   To customize the behaviour of the update action the following callbacks can
   be implemented:
 
-    * record/2
+    * JaResource.Record.record/2
+    * JaResource.Records.records/1
     * handle_update/3
     * JaResource.Attributes.permitted_attributes/3
 
@@ -65,6 +64,9 @@ defmodule JaResource.Update do
     end
   end
 
+  @doc """
+  Execute the update action on a given module implementing Update behaviour and conn.
+  """
   def call(controller, conn) do
     model      = controller.record(conn, conn.params["id"])
     merged     = JaResource.Attributes.from_params(conn.params)

--- a/lib/ja_resource/update.ex
+++ b/lib/ja_resource/update.ex
@@ -1,7 +1,6 @@
 defmodule JaResource.Update do
   use Behaviour
   import Plug.Conn
-  import Phoenix.Controller, only: [controller_module: 1]
 
   @moduledoc """
   Provides default `update/2` action implementation, `handle_update/3` callback.
@@ -66,8 +65,7 @@ defmodule JaResource.Update do
     end
   end
 
-  def call(conn) do
-    controller = controller_module(conn)
+  def call(controller, conn) do
     model      = controller.record(conn, conn.params["id"])
     merged     = JaResource.Attributes.from_params(conn.params)
     attributes = controller.permitted_attributes(conn, merged, :update)

--- a/test/ja_resource/create_test.exs
+++ b/test/ja_resource/create_test.exs
@@ -1,6 +1,7 @@
 defmodule JaResource.CreateTest do
   use ExUnit.Case
   use Plug.Test
+  alias JaResource.Create
 
   defmodule DefaultController do
     use Phoenix.Controller
@@ -27,32 +28,32 @@ defmodule JaResource.CreateTest do
   end
 
   test "default implementation renders 201 if valid" do
-    conn = prep_conn(:post, "/posts")
-    response = DefaultController.create(conn, ja_attrs(%{"title" => "valid"}))
+    conn = prep_conn(:post, "/posts", ja_attrs(%{"title" => "valid"}))
+    response = Create.call(DefaultController, conn)
     assert response.status == 201
   end
 
   test "default implementation renders 422 if invalid" do
-    conn = prep_conn(:post, "/posts")
-    response = DefaultController.create(conn, ja_attrs(%{"title" => "invalid"}))
+    conn = prep_conn(:post, "/posts", ja_attrs(%{"title" => "invalid"}))
+    response = Create.call(DefaultController, conn)
     assert response.status == 422
   end
 
   test "custom implementation accepts cons" do
-    conn = prep_conn(:post, "/posts")
-    response = ProtectedController.create(conn, ja_attrs(%{"title" => "valid"}))
+    conn = prep_conn(:post, "/posts", ja_attrs(%{"title" => "valid"}))
+    response = Create.call(ProtectedController, conn)
     assert response.status == 401
   end
 
   test "custom implementation handles {:ok, model}" do
-    conn = prep_conn(:post, "/posts")
-    response = CustomController.create(conn, ja_attrs(%{"title" => "valid"}))
+    conn = prep_conn(:post, "/posts", ja_attrs(%{"title" => "valid"}))
+    response = Create.call(CustomController, conn)
     assert response.status == 201
   end
 
   test "custom implementation handles {:error, errors}" do
-    conn = prep_conn(:post, "/posts")
-    response = CustomController.create(conn, ja_attrs(%{"title" => "invalid"}))
+    conn = prep_conn(:post, "/posts", ja_attrs(%{"title" => "invalid"}))
+    response = Create.call(CustomController, conn)
     assert response.status == 422
   end
 

--- a/test/ja_resource/delete_test.exs
+++ b/test/ja_resource/delete_test.exs
@@ -1,6 +1,7 @@
 defmodule JaResource.DeleteTest do
   use ExUnit.Case
   use Plug.Test
+  alias JaResource.Delete
 
   defmodule DefaultController do
     use Phoenix.Controller
@@ -23,37 +24,37 @@ defmodule JaResource.DeleteTest do
   end
 
   test "default implementation renders 404 if record not found" do
-    conn = prep_conn(:delete, "/posts/404")
-    response = DefaultController.delete(conn, %{"id" => 404})
+    conn = prep_conn(:delete, "/posts/404", %{"id" => 404})
+    response = Delete.call(DefaultController, conn)
     assert response.status == 404
   end
 
   test "default implementation returns 204 if record found" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
-    conn = prep_conn(:delete, "/posts/#{post.id}")
-    response = DefaultController.delete(conn, %{"id" => post.id})
+    conn = prep_conn(:delete, "/posts/#{post.id}", %{"id" => post.id})
+    response = Delete.call(DefaultController, conn)
     assert response.status == 204
   end
 
   test "custom implementation retuns 401 if not admin" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 401})
-    conn = prep_conn(:delete, "/posts/#{post.id}")
-    response = CustomController.delete(conn, %{"id" => post.id})
+    conn = prep_conn(:delete, "/posts/#{post.id}", %{"id" => post.id})
+    response = Delete.call(CustomController, conn)
     assert response.status == 401
   end
 
   test "custom implementation retuns 404 if no model" do
-    conn = prep_conn(:delete, "/posts/404")
+    conn = prep_conn(:delete, "/posts/404", %{"id" => 404})
             |> assign(:user, %{is_admin: true})
-    response = CustomController.delete(conn, %{"id" => 404})
+    response = Delete.call(CustomController, conn)
     assert response.status == 404
   end
 
   test "custom implementation retuns 204 if record found" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
-    conn = prep_conn(:delete, "/posts/#{post.id}")
+    conn = prep_conn(:delete, "/posts/#{post.id}", %{"id" => post.id})
             |> assign(:user, %{is_admin: true})
-    response = DefaultController.delete(conn, %{"id" => post.id})
+    response = Delete.call(DefaultController, conn)
     assert response.status == 204
   end
 

--- a/test/ja_resource/index_test.exs
+++ b/test/ja_resource/index_test.exs
@@ -1,6 +1,7 @@
 defmodule JaResource.IndexTest do
   use ExUnit.Case
   use Plug.Test
+  alias JaResource.Index
 
   defmodule DefaultController do
     use Phoenix.Controller
@@ -25,7 +26,7 @@ defmodule JaResource.IndexTest do
 
   test "default implementation returns all records" do
     conn = prep_conn(:get, "/posts/")
-    response = DefaultController.index(conn, %{})
+    response = Index.call(DefaultController, conn)
     assert response.status == 200
 
     # Note, not real json-api spec view
@@ -35,7 +36,7 @@ defmodule JaResource.IndexTest do
 
   test "custom implementation returns 401" do
     conn = prep_conn(:get, "/posts")
-    response = CustomController.index(conn, %{})
+    response = Index.call(CustomController, conn)
     assert response.status == 401
   end
 

--- a/test/ja_resource/plug_test.exs
+++ b/test/ja_resource/plug_test.exs
@@ -1,0 +1,59 @@
+defmodule JaResource.PlugTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  defmodule Example do
+    def handle_index(conn, _),  do: assign(conn, :handler, :index)
+  end
+
+  test "init returns all actions by default" do
+    assert [{:allowed, allowed}] = JaResource.Plug.init([])
+    assert allowed == [:index, :show, :create, :update, :delete]
+  end
+
+  test "init returns only valid whitelisted actions" do
+    assert [{:allowed, allowed}] = JaResource.Plug.init(only: [:index, :foo])
+    assert allowed == [:index]
+  end
+
+  test "init returns available minus blacklisted actions" do
+    assert [{:allowed, allowed}] = JaResource.Plug.init(except: [:index, :foo])
+    assert allowed == [:show, :create, :update, :delete]
+  end
+
+  test "it dispatches known, allowed actions to the behaviour" do
+    conn = %Plug.Conn{
+      private: %{
+        phoenix_controller: JaResource.PlugTest.Example,
+        phoenix_action:     :index
+      },
+      params: %{}
+    }
+    results = JaResource.Plug.call(conn, allowed: [:index])
+    assert results.assigns[:handler] == :index
+  end
+
+  test "it does not dispatch known, unallowed actions to the behaviour" do
+    conn = %Plug.Conn{
+      private: %{
+        phoenix_controller: JaResource.PlugTest.Example,
+        phoenix_action:     :index
+      },
+      params: %{}
+    }
+    results = JaResource.Plug.call(conn, allowed: [:show])
+    refute results.assigns[:handler]
+  end
+
+  test "it does not dispatch unknown actions to the behaviour" do
+    conn = %Plug.Conn{
+      private: %{
+        phoenix_controller: JaResource.PlugTest.Example,
+        phoenix_action:     :foo
+      },
+      params: %{}
+    }
+    results = JaResource.Plug.call(conn, allowed: [:index])
+    refute results.assigns[:handler]
+  end
+end

--- a/test/ja_resource/repo_test.exs
+++ b/test/ja_resource/repo_test.exs
@@ -1,0 +1,23 @@
+defmodule JaResource.RepoTest do
+  use ExUnit.Case
+
+  Application.put_env(:ja_resource, :repo, MyApp.Repo)
+
+  defmodule ExampleDefaultController do
+    use JaResource
+  end
+
+  defmodule ExampleCustomController do
+    use JaResource
+
+    def repo, do: MyApp.SecondaryRepo
+  end
+
+  test "Repo should be poplulated from settings by default" do
+    assert ExampleDefaultController.repo == MyApp.Repo
+  end
+
+  test "Repo can be overriden" do
+    assert ExampleCustomController.repo == MyApp.SecondaryRepo
+  end
+end

--- a/test/ja_resource/show_test.exs
+++ b/test/ja_resource/show_test.exs
@@ -1,6 +1,7 @@
 defmodule JaResource.ShowTest do
   use ExUnit.Case
   use Plug.Test
+  alias JaResource.Show
 
   defmodule DefaultController do
     use Phoenix.Controller
@@ -17,8 +18,8 @@ defmodule JaResource.ShowTest do
   end
 
   test "default implementation return 404 if not found" do
-    conn = prep_conn(:get, "/posts/404")
-    response = DefaultController.show(conn, %{"id" => 404})
+    conn = prep_conn(:get, "/posts/404", %{"id" => 404})
+    response = Show.call(DefaultController, conn)
     assert response.status == 404
     {:ok, body} = Poison.decode(response.resp_body)
     assert body == %{"action" => "errors.json",
@@ -27,15 +28,15 @@ defmodule JaResource.ShowTest do
   end
 
   test "default implementation return 200 if found" do
-    conn = prep_conn(:get, "/posts/200")
+    conn = prep_conn(:get, "/posts/200", %{"id" => 200})
     JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
-    response = DefaultController.show(conn, %{"id" => 200})
+    response = Show.call(DefaultController, conn)
     assert response.status == 200
   end
 
   test "custom implementation return 401" do
-    conn = prep_conn(:get, "/posts/401")
-    response = CustomController.show(conn, %{"id" => 401})
+    conn = prep_conn(:get, "/posts/401", %{"id" => 401})
+    response = Show.call(CustomController, conn)
     assert response.status == 401
   end
 

--- a/test/ja_resource/update_test.exs
+++ b/test/ja_resource/update_test.exs
@@ -1,6 +1,7 @@
 defmodule JaResource.UpdateTest do
   use ExUnit.Case
   use Plug.Test
+  alias JaResource.Update
 
   defmodule DefaultController do
     use Phoenix.Controller
@@ -24,45 +25,44 @@ defmodule JaResource.UpdateTest do
   end
 
   test "default implementation renders 404 if record not found" do
-    conn = prep_conn(:put, "/posts/404")
-    response = DefaultController.update(conn, ja_attrs(404, %{"title" => "valid"}))
+    conn = prep_conn(:put, "/posts/404", ja_attrs(404, %{"title" => "valid"}))
+    response = Update.call(DefaultController, conn)
     assert response.status == 404
   end
 
   test "default implementation renders 200 if valid" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
-    conn = prep_conn(:put, "/posts/#{post.id}")
-    response = DefaultController.update(conn, ja_attrs(post.id, %{"title" => "valid"}))
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "valid"}))
+    response = Update.call(DefaultController, conn)
     assert response.status == 200
   end
 
   test "default implementation renders 422 if invalid" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 422})
-    conn = prep_conn(:put, "/posts/#{post.id}")
-    response = DefaultController.update(conn, ja_attrs(post.id, %{"title" => "invalid"}))
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "invalid"}))
+    response = Update.call(DefaultController, conn)
     assert response.status == 422
   end
 
   test "custom implementation renders conn if returned" do
-    conn = prep_conn(:put, "/posts/420")
-    response = CustomController.update(conn, ja_attrs(420, %{"title" => "valid"}))
+    conn = prep_conn(:put, "/posts/420", ja_attrs(420, %{"title" => "valid"}))
+    response = Update.call(CustomController, conn)
     assert response.status == 420
   end
 
   test "custom implementation renders 200 if valid" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
-    conn = prep_conn(:put, "/posts/#{post.id}")
-    response = CustomController.update(conn, ja_attrs(post.id, %{"title" => "valid"}))
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "valid"}))
+    response = Update.call(CustomController, conn)
     assert response.status == 200
   end
 
   test "custom implementation renders 422 if invalid" do
     {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 422})
-    conn = prep_conn(:put, "/posts/#{post.id}")
-    response = CustomController.update(conn, ja_attrs(post.id, %{"title" => "invalid"}))
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "invalid"}))
+    response = Update.call(CustomController, conn)
     assert response.status == 422
   end
-
 
   def prep_conn(method, path, params \\ %{}) do
     params = Map.merge(params, %{"_format" => "json"})

--- a/test/ja_resource_test.exs
+++ b/test/ja_resource_test.exs
@@ -1,23 +1,3 @@
 defmodule JaResourceTest do
   use ExUnit.Case
-
-  Application.put_env(:ja_resource, :repo, MyApp.Repo)
-
-  defmodule ExampleDefaultController do
-    use JaResource
-  end
-
-  defmodule ExampleCustomController do
-    use JaResource
-
-    def repo, do: MyApp.SecondaryRepo
-  end
-
-  test "Repo should be poplulated from settings by default" do
-    assert ExampleDefaultController.repo == MyApp.Repo
-  end
-
-  test "Repo can be overriden" do
-    assert ExampleCustomController.repo == MyApp.SecondaryRepo
-  end
 end


### PR DESCRIPTION
This changes how the library is imlemented significantly while keeping
the API _mostly_ the same. Instead of defining the action functions on
your controller for you we instead intercept calls to those actions via
a plug and dispatch them to the behaviour. The behavour then hits the
callbacks as required to serve the request.