### PR TITLE
Fixed typo in lib/ja_resource.ex

### DIFF
--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -38,7 +38,7 @@ defmodule JaResource do
     end
   end
 
-  @behavour Plug
+  @behaviour Plug
   defdelegate init(opts),       to: JaResource.Plug
   defdelegate call(conn, opts), to: JaResource.Plug
 end


### PR DESCRIPTION
Self explanatory, not sure if I should also create an issue for it.